### PR TITLE
fix wildcard samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,8 +80,8 @@ indent_size = 2
       <tr><td><code>*</code></td><td>Matches any string of characters, except path separators (<code>/</code>)</td></tr>
       <tr><td><code>**</code></td><td>Matches any string of characters</td></tr>
       <tr><td><code>?</code></td><td>Matches any single character</td></tr>
-      <tr><td><code>name</code></td><td>Matches any single character in <em>name</em></td></tr>
-      <tr><td><code>!name</code></td><td>Matches any single character not in <em>name</em></td></tr>
+      <tr><td><code>[name]</code></td><td>Matches any single character in <em>name</em></td></tr>
+      <tr><td><code>[!name]</code></td><td>Matches any single character not in <em>name</em></td></tr>
       <tr><td><code>{s1,s2,s3}</code></td><td>Matches any of the strings given (separated by commas) (<strong>Available since EditorConfig Core 0.11.0</strong>)</td></tr>
     </table>
 


### PR DESCRIPTION
it's otherwise unclear that it's talking about `[char-range]` in regex

it would be awsome if there would be sample there for the `[abc]` and `[!abc]` syntax
