### PR TITLE
Improve docs: Brance Expansion notation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = "utf-8"
+
 # 4 space indentation
 [*.py]
 indent_style = space


### PR DESCRIPTION
Add multiple file extension brace expansion notation example.

This is a result from this [Issue thread](https://github.com/editorconfig/editorconfig/issues/71#issuecomment-63531714).
