### PR TITLE
[WIP] Note native Github support and link to Ruby core library

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@ indent_size = 2
   <section id="create-a-plugin">
     <h3>Create a plugin</h3>
 
-    <p>EditorConfig plugins can be developed by using one of the EditorConfig core libraries.  The EditorConfig core libraries accept as input the file being edited, find and parse relevant <code>.editorconfig</code> files, and pass back the properties that should be used. Please ignore any unrecognized properties and property values in your editor plugin for future compatibility, since new properties and permitted values will be added in the future. Currently there is a <a href="https://github.com/editorconfig/editorconfig-core-c#readme">C library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-py#readme">Python library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-js#readme">JavaScript library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-java#readme">Java library</a>, and a <a href="https://github.com/editorconfig/editorconfig-core-net#readme">.NET library</a>.</p>
+    <p>EditorConfig plugins can be developed by using one of the EditorConfig core libraries.  The EditorConfig core libraries accept as input the file being edited, find and parse relevant <code>.editorconfig</code> files, and pass back the properties that should be used. Please ignore any unrecognized properties and property values in your editor plugin for future compatibility, since new properties and permitted values will be added in the future. Currently there is a <a href="https://github.com/editorconfig/editorconfig-core-c#readme">C library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-py#readme">Python library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-js#readme">JavaScript library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-java#readme">Java library</a>, a <a href="https://github.com/editorconfig/editorconfig-core-net#readme">.NET library</a>, and a <a href="https://github.com/editorconfig/editorconfig-core-ruby">Ruby library</a>.</p>
     <p>If you are planning on creating a new plugin, use the <a href="http://groups.google.com/group/editorconfig">mailing list</a> to let us know so we can help out and link to your plugin once it's created.  If you plan on using one of the EditorConfig cores as a library or command line interface, the <a href="http://docs.editorconfig.org">C library documentation</a>, <a href="http://pydocs.editorconfig.org">Python library documentation</a> or <a href="http://javadocs.editorconfig.org">Java library documentation</a> may be helpful.</p>
     <p>More details can be found on the <a href="https://github.com/editorconfig/editorconfig/wiki/Plugin-How-To">Plugin-How-To wiki page</a>.</p>
   </section>
@@ -187,7 +187,8 @@ indent_size = 2
       <li>EditorConfig Java Core: <a href="https://github.com/denofevil">Dennis Ushakov</a></li>
       <li>EditorConfig Javascript Core: <a href="http://treyhunner.com">Trey Hunner</a> and <a href="http://jediscode.blogspot.com">Jed Mao</a></li>
       <li>EditorConfig Python Core: <a href="http://treyhunner.com">Trey Hunner</a></li>
-      <li>EditorConfig .NET Core: <a href="http://localghost.io/">Martijn Laarman</a>
+      <li>EditorConfig .NET Core: <a href="http://localghost.io/">Martijn Laarman</a></li>
+      <li>EditorConfig Ruby Core: <a href="https://github.com/josh">Joshua Peek</a> and <a href="https://github.com/brianmario">Brian Lopez</a></li>
     </ul>
     
 

--- a/index.html
+++ b/index.html
@@ -125,6 +125,7 @@ indent_size = 2
     <li><a href="http://barebones.com/support/technotes/editorconfig.html"><img src="logos/bbedit.png" title="BBEdit"><span>BBEdit</span></a></li>
     <li><a href="https://panic.com/coda/plugins.php#Plugins"><img src="logos/coda.png" alt="Coda logo"><span>Coda</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/clion.png" alt="CLion logo"><span>CLion</span></a></li>
+    <li><a href="https://github.com/RReverser/github-editorconfig#readme"><img src="logos/github.png" alt="GitHub logo" title="GitHub (code viewer and editor)"><span>GitHub</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/intellijIDEA.png" alt="intelliJ logo"><span>intelliJ</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rubyMine.png" alt="RubyMine logo"><span>RubyMine</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair logo"><span>SourcLair</span></a></li>
@@ -144,7 +145,6 @@ indent_size = 2
     <li><a href="https://github.com/editorconfig/editorconfig-emacs#readme"><img src="logos/emacs.png" alt="Emacs logo"><span>Emacs</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-geany#readme"><img src="logos/geany.png" alt="Geany logo"><span>Geany</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-gedit#readme"><img src="logos/gedit.png" alt="Gedit logo"><span>Gedit</span></a></li>
-    <li><a href="https://github.com/RReverser/github-editorconfig#readme"><img src="logos/github.png" alt="GitHub logo" title="GitHub (code viewer and editor)"><span>GitHub</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-jedit#readme"><img src="logos/jedit.png" alt="jEdit logo"><span>jEdit</span></a></li>
     <li><a href="https://github.com/welovecoding/editorconfig-netbeans#readme"><img src="logos/NetBeans.png" alt="NetBeans logo"><span>NetBeans</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-notepad-plus-plus#readme"><img src="logos/notepad.png" alt="Notepad++ logo"><span>Notepad++</span></a></li>


### PR DESCRIPTION
Github added support for EditorConfig last week.  This required a Ruby core library which was created by @josh and @brianmario.

This change seems to include full support for indentation when viewing diffs and file blobs and nearly full support for indentation when editing files (`tab_width` is not supported independently of `indent_size`, similar to the way Gedit and other plugins handle it).  No other properties appear to be supported by the editor currently.

Indentation when viewing files is by far the most important support needed on Github given that nearly all Github users view files in the browser (through pull requests or otherwise).

I believe the current [Github browser extension][extension] by @RReverser also only includes support for indentation.  If this is the case, this browser extension may no longer be necessary.

If the Github browser extension is no longer necessary, how should we note the Github support on the EditorConfig homepage?

I see a couple possibilities:

1. Link to a landing page of sorts that notes that Github now supports EditorConfig and explaining the extent of the support

2. Use an in-page dialog box to note the support (don't link to another page)

3. Continue to link to the Github browser extension README file and update the README file to note the native support

I am leaning toward option 1.  I like the idea of a page dedicated to explaining Github's support of EditorConfig similar to the way it is explained for some of the other editors that natively support it.  This page could be controlled and hosted on github.com (maybe help. or blog.), editorconfig.org, or elsewhere.

[extension]: https://github.com/RReverser/github-editorconfig