### PR TITLE
Correct section listing for Coda

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,6 @@ indent_size = 2
 
   <ul class="editor-logos">
     <li><a href="http://barebones.com/support/technotes/editorconfig.html"><img src="logos/bbedit.png" title="BBEdit"><span>BBEdit</span></a></li>
-    <li><a href="https://panic.com/coda/plugins.php#Plugins"><img src="logos/coda.png" alt="Coda logo"><span>Coda</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/clion.png" alt="CLion logo"><span>CLion</span></a></li>
     <li><a href="https://github.com/RReverser/github-editorconfig#readme"><img src="logos/github.png" alt="GitHub logo" title="GitHub (code viewer and editor)"><span>GitHub</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/intellijIDEA.png" alt="intelliJ logo"><span>intelliJ</span></a></li>
@@ -141,6 +140,7 @@ indent_size = 2
     <li><a href="https://plugins.jetbrains.com/plugin/7294"><img src="logos/appCode.png" alt="AppCode logo"><span>AppCode</span></a></li>
     <li><a href="https://github.com/sindresorhus/atom-editorconfig#readme"><img src="logos/atom.png" alt="Atom logo"><span>Atom</span></a></li>
     <li><a href="https://github.com/kidwm/brackets-editorconfig/"><img src="logos/brackets.png" alt="Brackets logo"><span>Brackets</span></a></li>
+    <li><a href="https://panic.com/coda/plugins.php#Plugins"><img src="logos/coda.png" alt="Coda logo"><span>Coda</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-codeblocks#readme"><img src="logos/codeblocks.png" alt="Code::Block logo"><span>Code::Block</span></a></li>
     <li><a href="https://github.com/ncjones/editorconfig-eclipse#readme"><img src="logos/eclipse.png" alt="Eclipse logo"><span>Eclipse</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-emacs#readme"><img src="logos/emacs.png" alt="Emacs logo"><span>Emacs</span></a></li>


### PR DESCRIPTION
It does not have built-in support; requires a plugin. Link to plugins page was already correct.