### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+.DS_Store


### PR DESCRIPTION
Useful for when you open up the images directory in the finder window on your Mac. This was the change that I previously backed out from the previous pull request.