### PR TITLE
Update VS Code extension link

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ indent_size = 2
     <li><a href="https://github.com/Mr0grog/editorconfig-textmate#readme"><img src="logos/textmate.png" alt="TextMate logo"><span>TextMate</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-vim#readme"><img src="logos/vim.png" alt="Vim logo"><span>Vim</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-visualstudio#readme"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
-    <li><a href="https://marketplace.visualstudio.com/items/chrisdias.vscodeEditorConfig"><img src="logos/visualstudio-code.png" alt="Visual Studio Code logo"><span>Visual Studio Code</span></a></li>
+    <li><a href="https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig"><img src="logos/visualstudio-code.png" alt="Visual Studio Code logo"><span>Visual Studio Code</span></a></li>
     <li><a href="https://github.com/MarcoSero/EditorConfig-Xcode"><img src="logos/xcode.png" alt="Xcode logo"><span>Xcode</span></a></li>
   </ul>
   <div style="clear: both;"></div>
@@ -183,7 +183,7 @@ indent_size = 2
 
   <section id="contributors">
     <h3>Main Contributors</h3>
-    
+
     <p>Core libraries:</p>
     <ul>
       <li>EditorConfig C Core: <a href="http://www.topbug.net">Hong Xu</a> and <a href="http://treyhunner.com">Trey Hunner</a></li>
@@ -193,7 +193,7 @@ indent_size = 2
       <li>EditorConfig .NET Core: <a href="http://localghost.io/">Martijn Laarman</a></li>
       <li>EditorConfig Ruby Core: <a href="https://github.com/josh">Joshua Peek</a> and <a href="https://github.com/brianmario">Brian Lopez</a></li>
     </ul>
-    
+
 
     <p>Editor Plugins:</p>
     <ul>
@@ -216,7 +216,7 @@ indent_size = 2
                                 <a href="http://github.com/chrisdias">Chris Dias</a> (for VS Code)</li>
       <li>Xcode plugin: <a href="http://marcosero.com/">Marco Sero</a></li>
     </ul>
-    
+
 
     <p>
     EditorConfig logos drawn by <a href="http://squirrelmuffins.com">Kat On</a>. Website by <a href="http://treyhunner.com">Trey Hunner</a> and <a href="http://www.topbug.net">Hong Xu</a>.  Please attribute appropriately.


### PR DESCRIPTION
Microsoft [has deprecated](https://github.com/Microsoft/vscode-editorconfig#editor-config-for-visual-studio-code) their extension in favor of ours, so I've updated the link accordingly.