### PR TITLE
Change Visual Studio to "no plugin necessary"

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@ indent_size = 2
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rubyMine.png" alt="RubyMine logo"><span>RubyMine</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair logo"><span>SourcLair</span></a></li>
     <li><a href="https://tortoisegit.org/"><img src="logos/TortoiseGit.png" alt="TortoiseGit logo"><span>TortoiseGit</span></a></li>
-    <li><a href="https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
+    <li><a href="https://github.com/editorconfig/editorconfig-visualstudio#readme"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/webStorm.png" alt="WebStorm logo"><span>WebStorm</span></a></li>
   </ul>
   <div style="clear: both;"></div>

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@ indent_size = 2
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rubyMine.png" alt="RubyMine logo"><span>RubyMine</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair logo"><span>SourcLair</span></a></li>
     <li><a href="https://tortoisegit.org/"><img src="logos/TortoiseGit.png" alt="TortoiseGit logo"><span>TortoiseGit</span></a></li>
-    <li><a href="https://github.com/editorconfig/editorconfig-visualstudio#readme"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
+    <li><a href="https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/webStorm.png" alt="WebStorm logo"><span>WebStorm</span></a></li>
   </ul>
   <div style="clear: both;"></div>

--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@ indent_size = 2
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rubyMine.png" alt="RubyMine logo"><span>RubyMine</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair logo"><span>SourcLair</span></a></li>
     <li><a href="https://tortoisegit.org/"><img src="logos/TortoiseGit.png" alt="TortoiseGit logo"><span>TortoiseGit</span></a></li>
+    <li><a href="https://github.com/editorconfig/editorconfig-visualstudio#readme"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/webStorm.png" alt="WebStorm logo"><span>WebStorm</span></a></li>
   </ul>
   <div style="clear: both;"></div>
@@ -160,7 +161,6 @@ indent_size = 2
     <li><a href="https://github.com/editorconfig/editorconfig-textadept#readme"><img src="logos/textadept.png" alt="Textadept logo"><span>Textadept</span></a></li>
     <li><a href="https://github.com/Mr0grog/editorconfig-textmate#readme"><img src="logos/textmate.png" alt="TextMate logo"><span>TextMate</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-vim#readme"><img src="logos/vim.png" alt="Vim logo"><span>Vim</span></a></li>
-    <li><a href="https://github.com/editorconfig/editorconfig-visualstudio#readme"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro logo"><span>Visual Studio Professional</span></a></li>
     <li><a href="https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig"><img src="logos/visualstudio-code.png" alt="Visual Studio Code logo"><span>Visual Studio Code</span></a></li>
     <li><a href="https://github.com/MarcoSero/EditorConfig-Xcode"><img src="logos/xcode.png" alt="Xcode logo"><span>Xcode</span></a></li>
   </ul>


### PR DESCRIPTION
Per @Mpdreamz's [tweet](https://twitter.com/Mpdreamz/status/801170946555985920)

Maybe we should wait until after VS2017 is officially released to merge this.

Also where should this link point to?