### PR TITLE
Move Komodo to no plugin section and fix URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@ indent_size = 2
     <li><a href="https://github.com/RReverser/github-editorconfig#readme"><img src="logos/github.png" alt="GitHub logo" title="GitHub (code viewer and editor)"><span>GitHub</span></a></li>
     <li><a href="https://gogs.io"><img src="logos/gogs.png" alt="Gogs logo"><span>Gogs</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/intellijIDEA.png" alt="intelliJ logo"><span>intelliJ</span></a></li>
+    <li><a href="https://www.activestate.com/blog/2015/07/editorconfig-your-komodo"><img src="logos/komodo.png" alt="Komodo logo"><span>Komodo</span></a></li>
     <li><a href="https://plugins.jetbrains.com/plugin/7294"><img src="logos/pyCharm.png" alt="PyCharm logo"><span>PyCharm</span></a></li>
     <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rubyMine.png" alt="RubyMine logo"><span>RubyMine</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair logo"><span>SourcLair</span></a></li>
@@ -152,7 +153,6 @@ indent_size = 2
     <li><a href="https://github.com/editorconfig/editorconfig-geany#readme"><img src="logos/geany.png" alt="Geany logo"><span>Geany</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-gedit#readme"><img src="logos/gedit.png" alt="Gedit logo"><span>Gedit</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-jedit#readme"><img src="logos/jedit.png" alt="jEdit logo"><span>jEdit</span></a></li>
-    <li><a href="http://komodoide.com/resources/addons/komodo--editorconfig/"><img src="logos/komodo.png" alt="Komodo logo"><span>Komodo</span></a></li>
     <li><a href="https://github.com/welovecoding/editorconfig-netbeans#readme"><img src="logos/NetBeans.png" alt="NetBeans logo"><span>NetBeans</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-notepad-plus-plus#readme"><img src="logos/notepad.png" alt="Notepad++ logo"><span>Notepad++</span></a></li>
     <li><a href="https://plugins.jetbrains.com/plugin/7294"><img src="logos/phpStorm.png" alt="PHPStorm logo"><span>PHPStorm</span></a></li>


### PR DESCRIPTION
Komodo announced they'd have built-in support for EditorConfig in version 9.2 which was released last year.