### PR TITLE
Remove link to Xcode plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,6 @@ indent_size = 2
     <li><a href="https://github.com/Mr0grog/editorconfig-textmate#readme"><img src="logos/textmate.png" alt="TextMate"><span>TextMate</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-vim#readme"><img src="logos/vim.png" alt="Vim"><span>Vim</span></a></li>
     <li><a href="https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig"><img src="logos/visualstudio-code.png" alt="Visual Studio Code"><span>Visual Studio Code</span></a></li>
-    <li><a href="https://github.com/MarcoSero/EditorConfig-Xcode"><img src="logos/xcode.png" alt="Xcode"><span>Xcode</span></a></li>
   </ul>
 
   <div style="clear: both;"></div>


### PR DESCRIPTION
Closes #89 

As I mentioned in #89, I didn't delete the Xcode icon.