### PR TITLE
Use jekyll.environment

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,11 +1,29 @@
+# EditorConfig website
+
 This is the source of the website https://editorconfig.org/
 
-To update the website, push the master branch
+The EditorConfig website are static HTML pages that are generated with [Jekyll](https://jekyllrb.com/) and it is hosted on [GitHub Pages](https://pages.github.com/). Every `git push` to the `master` branch automatically updates the website.
 
-To run in development mode:
-``jekyll serve --config _config.yml,_config-dev.yml``
+## Local development
 
-This way google analytics is disabled during testing and the url will be changed to `localhost:4000`.
+For local development make sure Ruby and Jekyll are installed as described in the [Jekyll docs](https://jekyllrb.com/docs/installation/).
+
+[Jekyll Environments](https://jekyllrb.com/docs/configuration/environments/) are used to distinguish between development and production. In the production environment Google Analytics is enabled.
+
+To run the development environment simply use:
+
+```bash
+jekyll serve
+```
+
+To run the production environment locally use:
+```bash
+JEKYLL_ENV=production jekyll serve
+```
+
+GitHub Pages automatically build and runs the site in the production environment.
+
+## Blog
 
 To add posts to the blog, add a page in the `_posts` subdir as described in [Jekyll docs](https://jekyllrb.com/docs/posts/). Create a [pull request](https://github.com/editorconfig/editorconfig.github.com/pulls) to get your post included on the website.
 

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,2 +1,0 @@
-analytics: none
-url: http://localhost:4000

--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,4 @@ title: "EditorConfig"
 description: "EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs."
 url: https://editorconfig.org
 permalink: pretty
-analytics: google
 exclude: [ 'ReadMe.md', '.gitignore', '.editorconfig' ]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,7 +88,7 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/1.4.0/js/bootstrap-scrollspy.min.js"></script>
 
-{% if site.analytics == 'google' %}
+{% if jekyll.environment == "production" %}
 <script type="text/javascript">
 
   var _gaq = _gaq || [];


### PR DESCRIPTION
Use `jekyll.environment` instead of `site.analytics`.

This is the standard way of Jekyll to distinguish between the development and production environment.

This way there is longer a need for `_config-dev.yml`.