### PR TITLE
Only show the ads in production

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,7 +8,7 @@ The EditorConfig website are static HTML pages that are generated with [Jekyll](
 
 For local development make sure Ruby and Jekyll are installed as described in the [Jekyll docs](https://jekyllrb.com/docs/installation/).
 
-[Jekyll Environments](https://jekyllrb.com/docs/configuration/environments/) are used to distinguish between development and production. In the production environment Google Analytics is enabled.
+[Jekyll Environments](https://jekyllrb.com/docs/configuration/environments/) are used to distinguish between development and production. In the production environment Google Analytics and Carbon Ads are enabled.
 
 To run the development environment simply use:
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -68,7 +68,9 @@
        })();
     </script>
 
+{% if jekyll.environment == "production" %}
     <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CK7I4KQE&placement=editorconfigorg" id="_carbonads_js"></script>
+{% endif%}
 
   </div>
 


### PR DESCRIPTION
When you are developing the website locally, (most of the time) you don't want to be bothered by the ads. So only show them in the production environment.

On GitHub Pages this works as expected. The analytics currently used in the site use the same check.