### PR TITLE
Make Pre-Installed Linkable, Extension Download Section More Specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@ indent_size = 2
 
 </section>
 
-<section id="download">
+<section id="pre-installed">
 
   <h2>No Plugin Necessary</h2>
 
@@ -154,6 +154,10 @@ indent_size = 2
   </ul>
   <div style="clear: both;"></div>
 
+</section>
+
+<section id="download">
+  
   <h2>Download a Plugin</h2>
 
   <h3>Editor</h3>


### PR DESCRIPTION
Allows links to https://editorconfig.org/#pre-installed vs https://editorconfig.org/#download, both sections have become quite large so differentiating can be helpful.