### PR TITLE
Set overflow for sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -59,6 +59,8 @@ footer { margin: 1em; font-size: 0.75em; text-align: center; }
   clear: both;
 }
 .container > #sidebar {
+  height: 100vh;
+  overflow: scroll;
   position: fixed;
   top: 0;
   width: 11em;


### PR DESCRIPTION
The content of the sidebar is not clickable if the vertical viewport is too narrow.