### PR TITLE
default.html: remove google plus

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,19 +54,8 @@
     <div class="social-sharing-button"><a href="{{ site.baseurl}}/blog/feed.xml"><img src="{{ site.baseurl}}/blog/feed-icon.svg" alt="RSS feed icon" title="Subscribe to blog posts"></a></div>
     <!-- tweet button -->
     <a href="https://twitter.com/share" class="twitter-share-button social-sharing-button" data-via="EditorConfig" data-size="medium">Tweet</a>
-    <!-- Google plus one -->
-    <div class="g-plusone social social-sharing-button" data-size="medium"></div>
-    <div style="clear: both;"></div>
 
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-
-    <script type="text/javascript">
-      (function() {
-       var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-       po.src = 'https://apis.google.com/js/plusone.js';
-       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-       })();
-    </script>
 
 {% if jekyll.environment == "production" %}
     <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CK7I4KQE&placement=editorconfigorg" id="_carbonads_js"></script>


### PR DESCRIPTION
It has been dead since 2019-04-02:

https://support.google.com/googlecurrents/answer/9195133

Added on commit 5a09d9c ("Add tweet and Google +1 button.").