### PR TITLE
default.html: remove scrollspy

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
       <a class="logo" href="{{ site.baseurl }}/"><img itemprop="logo" src="{{ site.baseurl }}/logo.png" alt="EditorConfig mouse head"></a>
     </div>
     <nav>
-    <ol data-scrollspy="scrollspy">
+    <ol>
       <li><a href="{{ site.baseurl }}/#overview">What is EditorConfig?</a></li>
       <li><a href="{{ site.baseurl }}/#example-file">Example File</a></li>
       <li><a href="{{ site.baseurl }}/#file-location">File Location</a></li>
@@ -78,9 +78,6 @@
     </footer>
   </div>
 </div>
-
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/1.4.0/js/bootstrap-scrollspy.min.js"></script>
 
 {% if jekyll.environment == "production" %}
 <script type="text/javascript">


### PR DESCRIPTION
Added on commit 36ad237 ("Add left menu bar nav with scrollspy support")
and commit 6371fe0 ("use minified scrollspy.min.js on cdn").

From my testing on this site, Scrollspy is not working.  The version
that is currently used is loaded from a CDN as a standalone file (65
SLOC unminified)[1].  But on later Bootstrap versions, it does not seem
to be possible to load Scrollspy by itself, as only the entire
bootstrap(.bundle)(.min).js appears to be available (~3262-4501 SLOC
unminified)[2][3][4].

Additionally, while Scrollspy is used on the navbar of Bootstrap's
documentation up until the 3.x series[5][6], since version 4.0.0
(released on 2018-01-18), the component is no longer used[7][8].

Considering that: It's a minor convenience feature, it depends on
JavaScript, the current stable version of the component requires loading
jQuery + Popper + the entire Bootstrap framework[9] and since Bootstrap
themselves stopped using it, put it to rest as well.

As a bonus, this makes jQuery no longer needed, so remove it too.

[1] https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/1.4.0/js/bootstrap-scrollspy.min.js
[2] https://cdnjs.com/libraries/twitter-bootstrap/2.0.0
[3] https://cdnjs.com/libraries/twitter-bootstrap/4.6.0
[4] https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.bundle.min.js
[5] https://getbootstrap.com/docs/versions/
[6] https://getbootstrap.com/docs/3.4/javascript/#scrollspy
[7] https://getbootstrap.com/docs/4.0/components/scrollspy/
[8] https://getbootstrap.com/docs/5.0/components/scrollspy/
[9] https://getbootstrap.com/docs/4.6/getting-started/introduction/