### PR TITLE
default.html: remove site.baseurl from anchors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,12 +28,12 @@
     </div>
     <nav>
     <ol data-scrollspy="scrollspy">
-      <li><a href="{{ site.baseurl }}/#overview">What is EditorConfig?</a></li>
-      <li><a href="{{ site.baseurl }}/#example-file">Example File</a></li>
-      <li><a href="{{ site.baseurl }}/#file-location">File Location</a></li>
-      <li><a href="{{ site.baseurl }}/#file-format-details">File Format Details</a></li>
-      <li><a href="{{ site.baseurl }}/#download">Download a Plugin</a></li>
-      <li><a href="{{ site.baseurl }}/#contributing">Contributing</a></li>
+      <li><a href="#overview">What is EditorConfig?</a></li>
+      <li><a href="#example-file">Example File</a></li>
+      <li><a href="#file-location">File Location</a></li>
+      <li><a href="#file-format-details">File Format Details</a></li>
+      <li><a href="#download">Download a Plugin</a></li>
+      <li><a href="#contributing">Contributing</a></li>
       <li><a href="{{ site.baseurl }}/blog"><strong>Blog</strong></a></li>
     </ol>
     </nav>


### PR DESCRIPTION
For simplicity, as they are not needed.  Reducing the noise also makes
it easier to see (and grep for) links to resources outside of the
current page, especially in the browser inspector.

---

**Note**: This conflicts with #142, but if/when one branch is merged, I can
rebase the other one.
