### PR TITLE
index.html: move overview id from h2 to section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@ layout: default
 description: EditorConfig is a file format and collection of text editor plugins for maintaining consistent coding styles between different editors and IDEs.
 ---
 
-<section>
+<section id="overview">
 
-  <h2 id="overview">What is EditorConfig?</h2>
+  <h2>What is EditorConfig?</h2>
 
   <p>EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs.  The EditorConfig project consists of <strong>a file format</strong> for defining coding styles and a collection of <strong>text editor plugins</strong> that enable editors to read the file format and adhere to defined styles.  EditorConfig files are easily readable and they work nicely with version control systems.</p>
 


### PR DESCRIPTION
Every other id attribute on this document is inside of a section tag.

This amends commit 1ec7cd4 ("Use sections as anchors instead of
headers").