### PR TITLE
Revert "default.html: remove site.baseurl from anchors (#145)"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,12 +28,12 @@
     </div>
     <nav>
     <ol data-scrollspy="scrollspy">
-      <li><a href="#overview">What is EditorConfig?</a></li>
-      <li><a href="#example-file">Example File</a></li>
-      <li><a href="#file-location">File Location</a></li>
-      <li><a href="#file-format-details">File Format Details</a></li>
-      <li><a href="#download">Download a Plugin</a></li>
-      <li><a href="#contributing">Contributing</a></li>
+      <li><a href="{{ site.baseurl }}/#overview">What is EditorConfig?</a></li>
+      <li><a href="{{ site.baseurl }}/#example-file">Example File</a></li>
+      <li><a href="{{ site.baseurl }}/#file-location">File Location</a></li>
+      <li><a href="{{ site.baseurl }}/#file-format-details">File Format Details</a></li>
+      <li><a href="{{ site.baseurl }}/#download">Download a Plugin</a></li>
+      <li><a href="{{ site.baseurl }}/#contributing">Contributing</a></li>
       <li><a href="{{ site.baseurl }}/blog"><strong>Blog</strong></a></li>
     </ol>
     </nav>


### PR DESCRIPTION
This reverts commit a4cd6975708a0c9543c51ac89084ce472678b20b.

That commit breaks the changed nav links on /blog, as the anchors are
specific to / (i.e.: the home page).

---

Link to the original PR: #145.
