### PR TITLE
default.html: add link to pre-installed on nav

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
       <li><a href="{{ site.baseurl }}/#example-file">Example File</a></li>
       <li><a href="{{ site.baseurl }}/#file-location">File Location</a></li>
       <li><a href="{{ site.baseurl }}/#file-format-details">File Format Details</a></li>
+      <li><a href="{{ site.baseurl }}/#pre-installed">No Plugin Necessary</a></li>
       <li><a href="{{ site.baseurl }}/#download">Download a Plugin</a></li>
       <li><a href="{{ site.baseurl }}/#contributing">Contributing</a></li>
       <li><a href="{{ site.baseurl }}/blog"><strong>Blog</strong></a></li>


### PR DESCRIPTION
The id in question was added on commit 9a9bda3 ("Make Pre-Installed
Linkable, Extension Download Section More Specific (#138)").
