### PR TITLE
_config.yml: remove redundant files from exclude list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,4 @@ title: "EditorConfig"
 description: "EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs."
 url: https://editorconfig.org
 permalink: pretty
-exclude: [ 'ReadMe.md', '.gitignore', '.editorconfig' ]
+exclude: [ 'ReadMe.md' ]


### PR DESCRIPTION
From [1]:

> Include
>
> Force inclusion of directories and/or files in the conversion.
> .htaccess is a good example since dotfiles are excluded by default.

See also [2].

[1] https://jekyllrb.com/docs/configuration/options/
[2] https://jekyllrb.com/docs/configuration/default/

---

After PR #150, I was going to add .gitattributes to the list, but then I found
the above on the Jekyll docs.
