### PR TITLE
default.html: make main div more visible

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,13 +65,13 @@
   </div>
 
   <div id="content">
-
     <header>
       <h1>EditorConfig</h1>
     </header>
+
     <div id="main" role="main">
       {{ content }}
-    </div>
+    </div> <!-- main -->
 
     <footer>
       The EditorConfig website is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.


### PR DESCRIPTION
Move blank line before it and mark the end tag.

This makes it easier to spot where it begins and ends in the output when
making changes to the content.  Also makes the "content" div look more
consistent.