### PR TITLE
.gitignore: add auto-generated jekyll paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-_site
+_site/
+.jekyll-cache/
+.jekyll-metadata
+
 .DS_Store


### PR DESCRIPTION
* .jekyll-cache/: created when running e.g: `jekyll serve` [1][2]
* .jekyll-metadata: created when running e.g.: `jekyll serve -I` [1][3]

[1] https://jekyllrb.com/docs/structure/
[2] https://github.com/jekyll/jekyll/pull/8648
[3] https://github.com/jekyll/jekyll/pull/8646