### PR TITLE
Point JetBrains IDE's to the Marketplace canonical URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,22 +135,22 @@ indent_size = 2
     <li><a href="https://docs.gitlab.com/ee/user/project/web_ide/index.html#configure-the-web-ide"><img src="logos/gitlab.png" alt="GitLab" title="GitLab"><span>GitLab</span></a></li>
     <li><a href="https://gitbucket.github.io/"><img src="logos/gitbucket.png" alt="GitBucket"><span>GitBucket</span></a></li>
     <li><a href="https://gogs.io"><img src="logos/gogs.png" alt="Gogs"><span>Gogs</span></a></li>
-    <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/intellijIDEA.png" alt="intelliJ logo"><span>intelliJ</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/intellijIDEA.png" alt="intelliJ logo"><span>intelliJ</span></a></li>
     <li><a href="https://gitlab.com/JakobDev/jdTextEdit"><img src="logos/jdTextEdit.png" alt="jdTextEdit logo"><span>jdTextEdit</span></a></li>
     <li><a href="https://api.kde.org/frameworks/ktexteditor/html/"><img src="logos/ktexteditor.png" alt="KTextEditor"><span>KTextEditor</span></a></li>
     <li><a href="https://www.activestate.com/blog/2015/07/editorconfig-your-komodo"><img src="logos/komodo.png" alt="Komodo"><span>Komodo</span></a></li>
     <li><a href="https://github.com/mawww/kakoune/wiki/EditorConfig/"><img src="logos/kakoune.png" alt="Kakoune"><span>Kakoune</span></a></li>
     <li><a href="https://github.com/mikerochip/editorconfig-monodevelop#readme"><img src="logos/monodevelop.png" alt="MonoDevelop"><span>MonoDevelop</span></a></li>
     <li><a href="https://nova.app/"><img src="logos/nova.png" alt="Nova"><span>Nova</span></a></li>
-    <li><a href="https://plugins.jetbrains.com/plugin/7294"><img src="logos/pyCharm.png" alt="PyCharm"><span>PyCharm</span></a></li>
-    <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/reSharper.png" alt="ReSharper"><span>ReSharper</span></a></li>
-    <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rider.png" alt="Rider"><span>Rider</span></a></li>
-    <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/rubyMine.png" alt="RubyMine"><span>RubyMine</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/pyCharm.png" alt="PyCharm"><span>PyCharm</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/reSharper.png" alt="ReSharper"><span>ReSharper</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/rider.png" alt="Rider"><span>Rider</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/rubyMine.png" alt="RubyMine"><span>RubyMine</span></a></li>
     <li><a href="https://sourcehut.org/"><img src="logos/sourcehut.png" alt="sourcehut"><span>sourcehut</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair"><span>SourcLair</span></a></li>
     <li><a href="https://tortoisegit.org/"><img src="logos/TortoiseGit.png" alt="TortoiseGit"><span>TortoiseGit</span></a></li>
     <li><a href="https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-v15.0#coding-convention-support-through-editorconfig"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro"><span>Visual Studio Professional</span></a></li>
-    <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/webStorm.png" alt="WebStorm"><span>WebStorm</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/" alt="WebStorm"><span>WebStorm</span></a></li>
     <li><a href="https://workingcopy.app/"><img src="logos/working-copy.png" alt="Working Copy"><span>Working Copy</span></a></li>
   </ul>
   <div style="clear: both;"></div>
@@ -165,10 +165,10 @@ indent_size = 2
   <p>To use EditorConfig with one of these editors, you will need to install a plugin.</p>
 
   <ul class="editor-logos">
-    <li><a href="https://plugins.jetbrains.com/plugin/7294"><img src="logos/appCode.png" alt="AppCode"><span>AppCode</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/appCode.png" alt="AppCode"><span>AppCode</span></a></li>
     <li><a href="https://github.com/sindresorhus/atom-editorconfig#readme"><img src="logos/atom.png" alt="Atom"><span>Atom</span></a></li>
     <li><a href="https://github.com/kidwm/brackets-editorconfig/"><img src="logos/brackets.png" alt="Brackets"><span>Brackets</span></a></li>
-    <li><a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/editorconfig"><img src="logos/clion.png" alt="CLion"><span>CLion</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/clion.png" alt="CLion"><span>CLion</span></a></li>
     <li><a href="https://panic.com/coda/plugins.php#Plugins"><img src="logos/coda.png" alt="Coda"><span>Coda</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-codeblocks#readme"><img src="logos/codeblocks.png" alt="Code::Block"><span>Code::Block</span></a></li>
     <li><a href="https://github.com/ncjones/editorconfig-eclipse#readme"><img src="logos/eclipse.png" alt="Eclipse"><span>Eclipse</span></a></li>
@@ -182,7 +182,7 @@ indent_size = 2
     <li><a href="https://github.com/welovecoding/editorconfig-netbeans#readme"><img src="logos/NetBeans.png" alt="NetBeans"><span>NetBeans</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-notepad-plus-plus#readme"><img src="logos/notepad.png" alt="Notepad++"><span>Notepad++</span></a></li>
     <li><a href="https://github.com/fszymanski/pluma-plugins/tree/master/editorconfig"><img src="logos/pluma.png" alt="Pluma"><span>Pluma</span></a></li>
-    <li><a href="https://plugins.jetbrains.com/plugin/7294"><img src="logos/phpStorm.png" alt="PHPStorm"><span>PHPStorm</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/phpStorm.png" alt="PHPStorm"><span>PHPStorm</span></a></li>
     <li><a href="https://github.com/sindresorhus/editorconfig-sublime#readme"><img src="logos/sublimetext.png" alt="Sublime Text"><span>Sublime Text</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-textadept#readme"><img src="logos/textadept.png" alt="Textadept"><span>Textadept</span></a></li>
     <li><a href="https://github.com/Mr0grog/editorconfig-textmate#readme"><img src="logos/textmate.png" alt="TextMate"><span>TextMate</span></a></li>


### PR DESCRIPTION
The project repo doesn't contain instructions how to actually install or use the plugin/support.