### PR TITLE
Add missing logo for WebStorm

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ indent_size = 2
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair"><span>SourcLair</span></a></li>
     <li><a href="https://tortoisegit.org/"><img src="logos/TortoiseGit.png" alt="TortoiseGit"><span>TortoiseGit</span></a></li>
     <li><a href="https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-v15.0#coding-convention-support-through-editorconfig"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro"><span>Visual Studio Professional</span></a></li>
-    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/" alt="WebStorm"><span>WebStorm</span></a></li>
+    <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/webStorm.png" alt="WebStorm"><span>WebStorm</span></a></li>
     <li><a href="https://workingcopy.app/"><img src="logos/working-copy.png" alt="Working Copy"><span>Working Copy</span></a></li>
   </ul>
   <div style="clear: both;"></div>


### PR DESCRIPTION
The "No Plugin Necessary" link for WebStorm is not using the existing logo for WebStorm.
It currently displays a blank spot where the logo should be.

This fixes that.