### PR TITLE
Use better link for MonoDevelop

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@ indent_size = 2
     <li><a href="https://api.kde.org/frameworks/ktexteditor/html/"><img src="logos/ktexteditor.png" alt="KTextEditor"><span>KTextEditor</span></a></li>
     <li><a href="https://www.activestate.com/blog/2015/07/editorconfig-your-komodo"><img src="logos/komodo.png" alt="Komodo"><span>Komodo</span></a></li>
     <li><a href="https://github.com/mawww/kakoune/wiki/EditorConfig/"><img src="logos/kakoune.png" alt="Kakoune"><span>Kakoune</span></a></li>
-    <li><a href="https://github.com/mikerochip/editorconfig-monodevelop#readme"><img src="logos/monodevelop.png" alt="MonoDevelop"><span>MonoDevelop</span></a></li>
+    <li><a href="https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-mac-relnotes-v7.5"><img src="logos/monodevelop.png" alt="MonoDevelop"><span>MonoDevelop</span></a></li>
     <li><a href="https://nova.app/"><img src="logos/nova.png" alt="Nova"><span>Nova</span></a></li>
     <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/pyCharm.png" alt="PyCharm"><span>PyCharm</span></a></li>
     <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/reSharper.png" alt="ReSharper"><span>ReSharper</span></a></li>


### PR DESCRIPTION
~~It appears this IDE requires a plugin. Disclaimer: I'm not actually familiar with MonoDevelop, I just noticed by randomly clicking links on the website.~~

Instead of linking to a plugin which isn't necessary anymore, link to the release notes which state that .editorconfig is supported natively.