### PR TITLE
Use the new sobdomain for the specifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ description: EditorConfig is a file format and collection of text editor plugins
 
   <h2>What's an EditorConfig file look like?</h2>
 
-  <p><em>(A <a href="https://editorconfig-specification.readthedocs.io/">formal specification of EditorConfig</a> is also available.)</em></p>
+  <p><em>(A <a href="https://spec.editorconfig.org/">formal specification of EditorConfig</a> is also available.)</em></p>
 
   <section id="example-file">
     <h3>Example file</h3>


### PR DESCRIPTION
With https://github.com/editorconfig/specification/issues/34 being done, the website needs to point to the proper location.