### PR TITLE
Move Vim to No Plugin Necessary section

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@ indent_size = 2
     <li><a href="https://sourcehut.org/"><img src="logos/sourcehut.png" alt="sourcehut"><span>sourcehut</span></a></li>
     <li><a href="https://www.sourcelair.com/features/editorconfig"><img src="logos/sourcelair.png" alt="SourcLair"><span>SourcLair</span></a></li>
     <li><a href="https://tortoisegit.org/"><img src="logos/TortoiseGit.png" alt="TortoiseGit"><span>TortoiseGit</span></a></li>
+    <li><a href="https://www.vim.org/"><img src="logos/vim.png" alt="Vim"><span>Vim</span></a></li>
     <li><a href="https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-v15.0#coding-convention-support-through-editorconfig"><img src="logos/visualstudio-pro.png" alt="Visual Studio Pro"><span>Visual Studio Professional</span></a></li>
     <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/webStorm.png" alt="WebStorm"><span>WebStorm</span></a></li>
     <li><a href="https://workingcopy.app/"><img src="logos/working-copy.png" alt="Working Copy"><span>Working Copy</span></a></li>
@@ -188,7 +189,6 @@ indent_size = 2
     <li><a href="https://github.com/sindresorhus/editorconfig-sublime#readme"><img src="logos/sublimetext.png" alt="Sublime Text"><span>Sublime Text</span></a></li>
     <li><a href="https://github.com/editorconfig/editorconfig-textadept#readme"><img src="logos/textadept.png" alt="Textadept"><span>Textadept</span></a></li>
     <li><a href="https://github.com/Mr0grog/editorconfig-textmate#readme"><img src="logos/textmate.png" alt="TextMate"><span>TextMate</span></a></li>
-    <li><a href="https://github.com/editorconfig/editorconfig-vim#readme"><img src="logos/vim.png" alt="Vim"><span>Vim</span></a></li>
     <li><a href="https://open-vsx.org/extension/EditorConfig/EditorConfig"><img src="logos/vscodium.png" alt="VSCodium"><span>VSCodium</span></a></li>
     <li><a href="https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig"><img src="logos/visualstudio-code.png" alt="Visual Studio Code"><span>Visual Studio Code</span></a></li>
   </ul>


### PR DESCRIPTION
The plugin has been bundled since vim/vim#12902.

Should I link to the homepage or the [plugin help page](https://vimhelp.org/usr_05.txt.html#editorconfig-install)?