### PR TITLE
Use lowercase characters in example URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ description: EditorConfig is a file format and collection of text editor plugins
     <p>Below is an example <code>.editorconfig</code> file setting end-of-line and indentation styles for Python and JavaScript files.</p>
     <div class="code-container">
 {% highlight ini %}
-# EditorConfig is awesome: https://EditorConfig.org
+# EditorConfig is awesome: https://editorconfig.org
 
 # top-most EditorConfig file
 root = true


### PR DESCRIPTION
A lot of projects seem to copy-paste the example config from https://editorconfig.org and then spend some extra time/effort to lowercase the URL.

Some examples:

- https://gitlab.archlinux.org/pacman/pacman/-/commit/24455cc5b206cc1dd783a6e219d506019ffee877
- https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/.editorconfig?ref_type=heads#L2
- https://github.com/gentoo/gentoo/blob/master/.editorconfig#L1

This is just my attempt to save that extra effort.