### PR TITLE
Clarify `.editorconfig` should be lower-cased

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ indent_size = 2
   <section id="file-location">
     <h3>Where are these files stored?</h3>
 
-    <p>When opening a file, EditorConfig plugins look for a file named <code>.editorconfig</code> in the directory of the opened file and in every parent directory.  A search for <code>.editorconfig</code> files will stop if the root filepath is reached or an EditorConfig file with <code>root=true</code> is found.</p>
+    <p>When opening a file, EditorConfig plugins look for a file named <code>.editorconfig</code> (all lowercase) in the directory of the opened file and in every parent directory.  A search for <code>.editorconfig</code> files will stop if the root filepath is reached or an EditorConfig file with <code>root=true</code> is found.</p>
 
     <p>EditorConfig files are read top to bottom and the most recent rules found take precedence.  Properties from matching EditorConfig sections are applied in the order they were read, so properties in closer files take precedence.</p>
 


### PR DESCRIPTION
See

- https://github.com/editorconfig/specification/pull/70
- https://github.com/editorconfig/editorconfig/issues/523