### PR TITLE
fix: hide sidebar scrollbars when there is no overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,7 +60,7 @@ footer { margin: 1em; font-size: 0.75em; text-align: center; }
 }
 .container > #sidebar {
   height: 100vh;
-  overflow: scroll;
+  overflow: auto;
   position: fixed;
   top: 0;
   width: 11em;


### PR DESCRIPTION
they are still displayed when there is not enough space