### PR TITLE
move emacs to the "No plugin necessary" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@ indent_size = 2
     <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/webStorm.png" alt="WebStorm"><span>WebStorm</span></a></li>
     <li><a href="https://workingcopy.app/"><img src="logos/working-copy.png" alt="Working Copy"><span>Working Copy</span></a></li>
     <li><a href="https://developer.apple.com/xcode/"><img src="logos/xcode.png" alt="Xcode"><span>Xcode</span></a></li>
+    <li><a href="https://www.gnu.org/software/emacs/"><img src="logos/emacs.png" alt="Emacs"><span>Emacs</span></a></li>
   </ul>
   <div style="clear: both;"></div>
 
@@ -200,7 +201,6 @@ indent_size = 2
       <li><a href="https://panic.com/coda/plugins.php#Plugins"><img src="logos/coda.png" alt="Coda"><span>Coda</span></a></li>
       <li><a href="https://github.com/editorconfig/editorconfig-codeblocks#readme"><img src="logos/codeblocks.png" alt="Code::Block"><span>Code::Block</span></a></li>
       <li><a href="https://github.com/ncjones/editorconfig-eclipse#readme"><img src="logos/eclipse.png" alt="Eclipse"><span>Eclipse</span></a></li>
-      <li><a href="https://github.com/editorconfig/editorconfig-emacs#readme"><img src="logos/emacs.png" alt="Emacs"><span>Emacs</span></a></li>
       <li><a href="https://github.com/nightroman/FarNet/tree/master/EditorKit"><img src="logos/far-manager.png" alt="Far Manager"><span>Far Manager</span></a></li>
       <li><a href="https://github.com/editorconfig/editorconfig-geany#readme"><img src="logos/geany.png" alt="Geany"><span>Geany</span></a></li>
       <li><a href="https://github.com/editorconfig/editorconfig-gedit#readme"><img src="logos/gedit.png" alt="Gedit"><span>Gedit</span></a></li>

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@ indent_size = 2
     <li><a href="https://plugins.jetbrains.com/plugin/7294-editorconfig/"><img src="logos/webStorm.png" alt="WebStorm"><span>WebStorm</span></a></li>
     <li><a href="https://workingcopy.app/"><img src="logos/working-copy.png" alt="Working Copy"><span>Working Copy</span></a></li>
     <li><a href="https://developer.apple.com/xcode/"><img src="logos/xcode.png" alt="Xcode"><span>Xcode</span></a></li>
-    <li><a href="https://www.gnu.org/software/emacs/"><img src="logos/emacs.png" alt="Emacs"><span>Emacs</span></a></li>
+    <li><a href="https://www.gnu.org/software/emacs/manual/html_node/emacs/EditorConfig-support.html"><img src="logos/emacs.png" alt="Emacs"><span>Emacs</span></a></li>
   </ul>
   <div style="clear: both;"></div>
 


### PR DESCRIPTION
since 30.1, emacs has editorconfig support built-in
https://www.gnu.org/software//emacs/manual/html_node/emacs/EditorConfig-support.html
https://www.gnu.org/software/emacs/news/NEWS.30.1
## changes
- emacs from the "Download a plugin" section to the "No plugin nessesarry section"