### PR TITLE
Increase container max-width to 60em (#547)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,7 +47,7 @@ footer { margin: 1em; font-size: 0.75em; text-align: center; }
   padding-right: 1.25em;
   zoom: 1;
   min-width: 40em;
-  max-width: 50em;
+  max-width: 60em;
   margin: 0 auto;
 }
 .container:before, .container:after {


### PR DESCRIPTION
This pull request resolves [#547](https://github.com/editorconfig/editorconfig/issues/547) by increasing the `.container`'s `max-width` from **50em to 60em**.

### 📌 Motivation
The current 50em width results in excessive wrapping of longer code lines (e.g., URLs and configuration comments). By increasing it to 60em:
- Code examples remain more readable.
- Visual breaks in single-line comments (like URLs) are reduced.
- Layout remains responsive on all standard screen sizes.

### ✅ Visual impact
- No changes to mobile responsiveness.
- Code blocks flow better on wider screens (≥1300px).

Tested locally in a simulated responsive layout. Looks consistent with the current site design.

---

Let me know if you'd prefer a different width (e.g., 65em or 70em) and I’ll update accordingly.
