### PR TITLE
fix(css): correct typo 'lyst-style-image' to 'list-style-image'

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -264,7 +264,7 @@ nav ul, nav ol { list-style: none; list-style-image: none; margin: 0; padding: 0
 
 nav ol { margin-top: 0; }
 
-ul.property-definitions { list-style: none; lyst-style-image: none; margin: 0; padding: 0; }
+ul.property-definitions { list-style: none; list-style-image: none; margin: 0; padding: 0; }
 ul.property-definitions li { margin: 1em 0 1em 1em; }
 .property-definitions dfn { font-style: normal; font-weight: bold; }
 .property-definitions q { font-family: monospace; }


### PR DESCRIPTION
This PR corrects a small typo in the main CSS file:
`lyst-style-image` (an invalid CSS property) is updated to the correct `list-style-image`.

Although the typo doesn't break layout — browsers ignore unknown properties — fixing it ensures:

Proper intent clarity

Cleaner validation and linting results

Better maintainability of the CSS codebase

No related issue was filed; this is a minor hygiene fix noticed during review.